### PR TITLE
Address PR #4 review findings — media module

### DIFF
--- a/lib/phoenix_kit_web/components/media_viewer.ex
+++ b/lib/phoenix_kit_web/components/media_viewer.ex
@@ -11,9 +11,18 @@ defmodule PhoenixKitWeb.Components.MediaViewer do
   ## Attrs
   - `id` — required
   - `files` — ordered list of file UUIDs (the navigable set)
-  - `current` — UUID currently shown (must be in `files`)
-  - `variants_map` — optional `%{uuid => variants}`; resolved internally if absent
-  - `file_structs` — optional `[%Storage.File{}]`; resolved internally if absent
+  - `current` — initial UUID to show (must be in `files`). Treated as a seed: once the
+    component is mounted, internal navigation state takes precedence over subsequent
+    `current` attr changes. This is intentional when the component is mount-gated
+    (`:if={...}`) so it remounts fresh on each open. A standalone consumer that keeps
+    the component mounted and wants to jump to a different image programmatically must
+    unmount and remount it.
+  - `variants_map` — optional `%{uuid => variants}`; resolved internally if nil/omitted.
+    Note: `%{}` (empty map) is truthy and counts as pre-resolved — pass `nil` or omit to
+    trigger internal resolution.
+  - `file_structs` — optional `[%Storage.File{}]`; resolved internally if nil/omitted.
+    Note: `[]` (empty list) is truthy and counts as pre-resolved — pass `nil` or omit to
+    trigger internal resolution.
   - `notify` — optional `{module, id}`; see Close below
 
   ## Close

--- a/lib/phoenix_kit_web/components/media_viewer.html.heex
+++ b/lib/phoenix_kit_web/components/media_viewer.html.heex
@@ -3,6 +3,7 @@
   class="modal"
   phx-hook="MediaViewerDialog"
   phx-target={@myself}
+  aria-labelledby={"#{@id}-title"}
 >
   <% preview_variants = Map.get(@variants_map, @current_uuid, []) %>
   <% preview_idx = Enum.find_index(@files, &(&1 == @current_uuid)) %>
@@ -64,7 +65,7 @@
 
       <%!-- Sidebar: filename + download --%>
       <div class="flex-[3] flex flex-col gap-3 p-4 overflow-y-auto lg:min-w-[220px] bg-base-100">
-        <h2 class="text-base font-bold break-all leading-tight pr-10">
+        <h2 id={"#{@id}-title"} class="text-base font-bold break-all leading-tight pr-10">
           {file_name}
         </h2>
 

--- a/lib/phoenix_kit_web/live/components/media_selector_modal.html.heex
+++ b/lib/phoenix_kit_web/live/components/media_selector_modal.html.heex
@@ -6,6 +6,7 @@
   data-close-event="close_modal"
   phx-click="close_modal"
   phx-target={@myself}
+  aria-labelledby="media-selector-modal-title"
 >
   <%!-- Modal Container --%>
   <div class="min-h-screen px-2 py-2 sm:px-4 sm:py-6 flex items-center justify-center">
@@ -20,7 +21,10 @@
         <div class="flex flex-col gap-3">
           <div class="flex justify-between items-start">
             <div>
-              <h2 class="text-xl sm:text-2xl font-bold text-base-content">
+              <h2
+                id="media-selector-modal-title"
+                class="text-xl sm:text-2xl font-bold text-base-content"
+              >
                 Select Media
               </h2>
               <p class="text-base-content/70 text-sm mt-1">

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -1464,12 +1464,19 @@ if (typeof window.Chart === "undefined") {
         if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
         const t = document.activeElement;
         if (t && (t.tagName === "INPUT" || t.tagName === "TEXTAREA" ||
-                  t.isContentEditable === true)) return;
+                  t.isContentEditable)) return;
         self.pushEventTo(self.el, "viewer_keydown", { key: e.key });
       };
 
       this.el.addEventListener("cancel", self._onCancel);
       this.el.addEventListener("keydown", self._onKey);
+    },
+    // Re-assert open state after LiveView patches children (e.g. prev/next step).
+    // The <dialog> opening tag has only stable attrs so morphdom rarely touches it,
+    // but this guard mirrors PkDialog._sync and removes the asymmetry between the
+    // two hooks.
+    updated() {
+      if (!this.el.open && typeof this.el.showModal === "function") this.el.showModal();
     },
     destroyed() {
       if (this._onCancel) this.el.removeEventListener("cancel", this._onCancel);

--- a/test/phoenix_kit_web/components/media_viewer_test.exs
+++ b/test/phoenix_kit_web/components/media_viewer_test.exs
@@ -40,6 +40,105 @@ defmodule PhoenixKitWeb.Components.MediaViewerTest do
     MediaViewer.handle_event(event, params, socket)
   end
 
+  # Minimal socket for calling update/2 — no pre-existing assigns.
+  defp fresh_socket, do: %Phoenix.LiveView.Socket{assigns: %{__changed__: %{}}}
+
+  describe "update/2" do
+    test "maps :current attr to :current_uuid assign" do
+      {:ok, socket} =
+        MediaViewer.update(
+          %{
+            id: "v1",
+            current: @u2,
+            files: [@u1, @u2],
+            variants_map: %{},
+            file_structs: [],
+            notify: nil
+          },
+          fresh_socket()
+        )
+
+      assert socket.assigns.current_uuid == @u2
+    end
+
+    test "stores :notify tuple in assigns" do
+      notify = {__MODULE__, "my-id"}
+
+      {:ok, socket} =
+        MediaViewer.update(
+          %{
+            id: "v1",
+            current: @u1,
+            files: [@u1],
+            variants_map: %{},
+            file_structs: [],
+            notify: notify
+          },
+          fresh_socket()
+        )
+
+      assert socket.assigns.notify == notify
+    end
+
+    test "pre-passed variants_map and file_structs are used without DB resolution" do
+      vm = %{@u1 => [%{variant_name: "original", url: "https://cdn/img.jpg"}]}
+      fs = [%{uuid: @u1, file_name: "img.jpg"}]
+
+      {:ok, socket} =
+        MediaViewer.update(
+          %{
+            id: "v1",
+            current: @u1,
+            files: [@u1],
+            variants_map: vm,
+            file_structs: fs,
+            notify: nil
+          },
+          fresh_socket()
+        )
+
+      assert socket.assigns.variants_map == vm
+      assert socket.assigns.file_structs == fs
+    end
+
+    test "assign_new(:current_uuid) preserves navigated state on re-render" do
+      # First update seeds current_uuid from :current
+      {:ok, s1} =
+        MediaViewer.update(
+          %{
+            id: "v1",
+            current: @u1,
+            files: [@u1, @u2],
+            variants_map: %{},
+            file_structs: [],
+            notify: nil
+          },
+          fresh_socket()
+        )
+
+      assert s1.assigns.current_uuid == @u1
+
+      # Simulate user navigating to @u2 (step_viewer mutates current_uuid)
+      s1_navigated = %{s1 | assigns: Map.put(s1.assigns, :current_uuid, @u2)}
+
+      # Re-render with same :current — assign_new preserves the navigated state
+      {:ok, s2} =
+        MediaViewer.update(
+          %{
+            id: "v1",
+            current: @u1,
+            files: [@u1, @u2],
+            variants_map: %{},
+            file_structs: [],
+            notify: nil
+          },
+          s1_navigated
+        )
+
+      assert s2.assigns.current_uuid == @u2
+    end
+  end
+
   describe "single-root constraint (stateful component)" do
     # Phoenix LiveView raises ArgumentError at runtime when rendered.root != true
     # for stateful components with an id. This constraint is NOT caught by


### PR DESCRIPTION
Follow-up to #4 (merged). Applies the code-review findings from that PR.

## Changes

- **`MediaViewerDialog` JS hook** — added an `updated()` callback that re-asserts `showModal()` if the `<dialog>` lost its `open` state. Mirrors the sibling `PkDialog` hook and guards against morphdom stripping the runtime `open` attribute should a dynamic attribute ever be added to the `<dialog>` tag.
- **`MediaViewer.update/2` test coverage** — added a `describe "update/2"` block: the `current`→`current_uuid` mapping, `notify` passthrough, pre-passed `variants_map`/`file_structs` skipping DB resolution, and `assign_new` preserving navigation state across re-renders.
- **Accessibility** — both `<dialog>` modals (`MediaViewer`, `MediaSelectorModal`) now set `aria-labelledby` pointing at their heading.
- **Moduledoc** — `MediaViewer`'s `current` attr documented as an initial seed (not a live tracker); `variants_map`/`file_structs` documented as "empty `%{}`/`[]` count as pre-resolved — pass `nil` to trigger internal resolution".
- Minor: dropped a redundant `=== true` in the hook's key filter.

## Evaluated but intentionally not changed

- `MediaViewer.update/2` `assign_new(:current_uuid)` not re-seeding from a new `current` — the only consumer (`MediaGallery`) mount-gates the viewer (`:if`), so it remounts fresh each open; re-seed tracking would be YAGNI. Documented instead.
- `MediaSelectorModal` `<dialog>` conversion — verified all 4 consumers (settings, authorization, user_form, media_gallery); mount-gated and always-mounted patterns are both handled correctly by `PkDialog`. No regression.
- `modal-box` `!important` chain, hardcoded `id`, focus-restore-on-close — left as-is (cosmetic / pre-existing / non-trivial; none blocking).

## Tests

`mix test test/phoenix_kit_web/components/` — 52 tests, 0 failures. `mix format` + `mix quality` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)