### PR TITLE
Media picker fix, search regression fix, and table-toolbar refactor for Users/Activity

### DIFF
--- a/lib/modules/storage/storage.ex
+++ b/lib/modules/storage/storage.ex
@@ -1192,10 +1192,15 @@ defmodule PhoenixKit.Modules.Storage do
     {:ok, folder}
   end
 
-  # Walks the folder tree from `root_uuid` down and returns every
-  # descendant uuid (including the root itself). Used by trash, restore,
-  # and permanent-delete to determine the affected subtree in one pass.
-  defp folder_subtree_uuids(root_uuid) do
+  @doc """
+  Walks the folder tree from `root_uuid` down and returns every descendant
+  folder uuid, including the root itself.
+
+  Used by trash, restore, and permanent-delete to determine the affected
+  subtree in one pass, and by scoped media listings that should include
+  files in nested folders.
+  """
+  def folder_subtree_uuids(root_uuid) do
     Stream.unfold([root_uuid], fn
       [] ->
         nil

--- a/lib/phoenix_kit_web/live/activity/index.html.heex
+++ b/lib/phoenix_kit_web/live/activity/index.html.heex
@@ -13,12 +13,60 @@
       subtitle="Business-level activity across the platform"
     />
 
-    <%!-- Filters --%>
-    <div class="bg-base-200 rounded-lg p-4 mb-6">
-      <.form for={%{}} phx-change="filter" class="flex flex-wrap gap-4 items-end">
-        <div class="form-control">
-          <label class="label"><span class="label-text">Module</span></label>
-          <select name="filter[module]" class="select select-bordered select-sm">
+    <%!-- Activity List --%>
+    <.table_default
+      id="activity-table"
+      variant="zebra"
+      size="sm"
+      class="w-full"
+      toggleable={true}
+      items={@entries}
+      card_title={fn entry -> entry.action end}
+      card_fields={
+        fn entry ->
+          fields = [
+            %{
+              label: "Actor",
+              value: if(entry.actor, do: entry.actor.email, else: "System")
+            }
+          ]
+
+          fields =
+            if entry.resource_type do
+              fields ++ [%{label: "Subject", value: entry.resource_type}]
+            else
+              fields
+            end
+
+          fields =
+            if entry.target do
+              fields ++ [%{label: "Target", value: entry.target.email}]
+            else
+              fields
+            end
+
+          fields =
+            if entry.metadata["role"] do
+              fields ++ [%{label: "Role", value: entry.metadata["role"]}]
+            else
+              fields
+            end
+
+          fields ++
+            [
+              %{
+                label: "Date",
+                value:
+                  "#{Calendar.strftime(entry.inserted_at, "%b %d, %Y %H:%M")} (#{format_time_ago(entry.inserted_at)})"
+              }
+            ]
+        end
+      }
+    >
+      <:toolbar_title>
+        <.form for={%{}} phx-change="filter" class="flex flex-wrap items-center gap-2">
+          <span class="text-sm text-base-content/70 whitespace-nowrap">Module:</span>
+          <select name="filter[module]" class="select select-sm w-36 min-w-0">
             <option value="">All Modules</option>
             <%= for mod <- @modules do %>
               <option value={mod} selected={@filter_module == mod}>
@@ -26,11 +74,8 @@
               </option>
             <% end %>
           </select>
-        </div>
-
-        <div class="form-control">
-          <label class="label"><span class="label-text">Mode</span></label>
-          <select name="filter[mode]" class="select select-bordered select-sm">
+          <span class="text-sm text-base-content/70 whitespace-nowrap">Mode:</span>
+          <select name="filter[mode]" class="select select-sm w-32 min-w-0">
             <option value="">All Modes</option>
             <%= for mode <- @modes do %>
               <option value={mode} selected={@filter_mode == mode}>
@@ -38,11 +83,8 @@
               </option>
             <% end %>
           </select>
-        </div>
-
-        <div class="form-control">
-          <label class="label"><span class="label-text">Action</span></label>
-          <select name="filter[action]" class="select select-bordered select-sm">
+          <span class="text-sm text-base-content/70 whitespace-nowrap">Action:</span>
+          <select name="filter[action]" class="select select-sm w-40 min-w-0">
             <option value="">All Actions</option>
             <%= for action <- @action_types do %>
               <option value={action} selected={@filter_action == action}>
@@ -50,11 +92,8 @@
               </option>
             <% end %>
           </select>
-        </div>
-
-        <div class="form-control">
-          <label class="label"><span class="label-text">Resource Type</span></label>
-          <select name="filter[resource_type]" class="select select-bordered select-sm">
+          <span class="text-sm text-base-content/70 whitespace-nowrap">Type:</span>
+          <select name="filter[resource_type]" class="select select-sm w-36 min-w-0">
             <option value="">All Types</option>
             <%= for rt <- @resource_types do %>
               <option value={rt} selected={@filter_resource_type == rt}>
@@ -62,195 +101,149 @@
               </option>
             <% end %>
           </select>
-        </div>
-      </.form>
-    </div>
-
-    <%!-- Activity List --%>
-    <%= if Enum.empty?(@entries) do %>
-      <div class="text-center py-12 text-base-content/60">
-        <.icon name="hero-bell-slash" class="w-12 h-12 mx-auto mb-2 opacity-50" />
-        <p>No activities recorded yet</p>
-      </div>
-    <% else %>
-      <.table_default
-        id="activity-table"
-        variant="zebra"
-        size="sm"
-        class="w-full"
-        toggleable={true}
-        items={@entries}
-        card_title={fn entry -> entry.action end}
-        card_fields={
-          fn entry ->
-            fields = [
-              %{
-                label: "Actor",
-                value: if(entry.actor, do: entry.actor.email, else: "System")
-              }
-            ]
-
-            fields =
-              if entry.resource_type do
-                fields ++ [%{label: "Subject", value: entry.resource_type}]
-              else
-                fields
-              end
-
-            fields =
-              if entry.target do
-                fields ++ [%{label: "Target", value: entry.target.email}]
-              else
-                fields
-              end
-
-            fields =
-              if entry.metadata["role"] do
-                fields ++ [%{label: "Role", value: entry.metadata["role"]}]
-              else
-                fields
-              end
-
-            fields ++
-              [
-                %{
-                  label: "Date",
-                  value:
-                    "#{Calendar.strftime(entry.inserted_at, "%b %d, %Y %H:%M")} (#{format_time_ago(entry.inserted_at)})"
-                }
-              ]
-          end
-        }
-      >
-        <:toolbar_title>
-          <span class="text-sm text-base-content/60">{@total} activities</span>
-        </:toolbar_title>
-        <:toolbar_actions>
-          <button type="button" phx-click="clear_filters" class="btn btn-ghost btn-sm">
-            Clear filters
+        </.form>
+      </:toolbar_title>
+      <:toolbar_actions>
+        <span class="text-sm text-base-content/60 whitespace-nowrap">
+          {@total} activities
+        </span>
+        <%= if @filter_module not in [nil, ""] or @filter_mode not in [nil, ""] or
+                   @filter_action not in [nil, ""] or @filter_resource_type not in [nil, ""] do %>
+          <button type="button" phx-click="clear_filters" class="btn btn-sm btn-outline">
+            <.icon name="hero-x-mark" class="w-4 h-4" /> Clear filters
           </button>
-        </:toolbar_actions>
-        <:card_header :let={entry}>
-          <span class={"badge badge-sm #{action_badge_color(entry.action)}"}>
-            {entry.action}
-          </span>
-        </:card_header>
+        <% end %>
+      </:toolbar_actions>
+      <:card_header :let={entry}>
+        <span class={"badge badge-sm #{action_badge_color(entry.action)}"}>
+          {entry.action}
+        </span>
+      </:card_header>
 
-        <:card_actions :let={entry}>
-          <.link
-            navigate={Routes.path("/admin/activity/#{entry.uuid}")}
-            class="btn btn-sm btn-outline btn-info"
-          >
-            <.icon name="hero-arrow-top-right-on-square" class="w-4 h-4" /> View
-          </.link>
-        </:card_actions>
+      <:card_actions :let={entry}>
+        <.link
+          navigate={Routes.path("/admin/activity/#{entry.uuid}")}
+          class="btn btn-sm btn-outline btn-info"
+        >
+          <.icon name="hero-arrow-top-right-on-square" class="w-4 h-4" /> View
+        </.link>
+      </:card_actions>
 
-        <.table_default_header>
-          <.table_default_row hover={false}>
-            <.table_default_header_cell>Module</.table_default_header_cell>
-            <.table_default_header_cell>Mode</.table_default_header_cell>
-            <.table_default_header_cell>Activity</.table_default_header_cell>
-            <.table_default_header_cell>Actor</.table_default_header_cell>
-            <.table_default_header_cell>Details</.table_default_header_cell>
-            <.table_default_header_cell>Subject</.table_default_header_cell>
-            <.table_default_header_cell>Date</.table_default_header_cell>
-            <.table_default_header_cell class="w-12"></.table_default_header_cell>
+      <.table_default_header>
+        <.table_default_row hover={false}>
+          <.table_default_header_cell>Module</.table_default_header_cell>
+          <.table_default_header_cell>Mode</.table_default_header_cell>
+          <.table_default_header_cell>Activity</.table_default_header_cell>
+          <.table_default_header_cell>Actor</.table_default_header_cell>
+          <.table_default_header_cell>Details</.table_default_header_cell>
+          <.table_default_header_cell>Subject</.table_default_header_cell>
+          <.table_default_header_cell>Date</.table_default_header_cell>
+          <.table_default_header_cell class="w-12"></.table_default_header_cell>
+        </.table_default_row>
+      </.table_default_header>
+
+      <.table_default_body>
+        <%= if Enum.empty?(@entries) do %>
+          <.table_default_row>
+            <.table_default_cell colspan={8}>
+              <div class="text-center py-12 text-base-content/60">
+                <.icon name="hero-bell-slash" class="w-12 h-12 mx-auto mb-2 opacity-50" />
+                <p>No activities recorded yet</p>
+              </div>
+            </.table_default_cell>
           </.table_default_row>
-        </.table_default_header>
-
-        <.table_default_body>
-          <%= for entry <- @entries do %>
-            <.table_default_row>
-              <.table_default_cell class="text-sm">
-                <%= if entry.module do %>
-                  <span class="badge badge-outline badge-xs">{entry.module}</span>
-                <% else %>
-                  <span class="text-base-content/30">—</span>
-                <% end %>
-              </.table_default_cell>
-              <.table_default_cell class="text-sm">
-                <%= if entry.mode do %>
-                  <span class={"badge badge-xs #{mode_badge_color(entry.mode)}"}>
-                    {entry.mode}
-                  </span>
-                <% else %>
-                  <span class="text-base-content/30">—</span>
-                <% end %>
-              </.table_default_cell>
-              <.table_default_cell>
-                <span class={"badge badge-sm #{action_badge_color(entry.action)}"}>
-                  {entry.action}
+        <% end %>
+        <%= for entry <- @entries do %>
+          <.table_default_row>
+            <.table_default_cell class="text-sm">
+              <%= if entry.module do %>
+                <span class="badge badge-outline badge-xs">{entry.module}</span>
+              <% else %>
+                <span class="text-base-content/30">—</span>
+              <% end %>
+            </.table_default_cell>
+            <.table_default_cell class="text-sm">
+              <%= if entry.mode do %>
+                <span class={"badge badge-xs #{mode_badge_color(entry.mode)}"}>
+                  {entry.mode}
                 </span>
-              </.table_default_cell>
-              <.table_default_cell class="text-sm">
-                <%= if entry.actor do %>
-                  <span class="font-semibold">{entry.actor.email}</span>
-                  <%= if entry.metadata["actor_role"] do %>
-                    <span class={[
-                      "badge badge-xs ml-1",
-                      if(entry.metadata["actor_role"] == "admin",
-                        do: "badge-warning",
-                        else: "badge-ghost"
-                      )
-                    ]}>
-                      {entry.metadata["actor_role"]}
-                    </span>
-                  <% end %>
-                <% else %>
-                  <span class="text-base-content/50">System</span>
+              <% else %>
+                <span class="text-base-content/30">—</span>
+              <% end %>
+            </.table_default_cell>
+            <.table_default_cell>
+              <span class={"badge badge-sm #{action_badge_color(entry.action)}"}>
+                {entry.action}
+              </span>
+            </.table_default_cell>
+            <.table_default_cell class="text-sm">
+              <%= if entry.actor do %>
+                <span class="font-semibold">{entry.actor.email}</span>
+                <%= if entry.metadata["actor_role"] do %>
+                  <span class={[
+                    "badge badge-xs ml-1",
+                    if(entry.metadata["actor_role"] == "admin",
+                      do: "badge-warning",
+                      else: "badge-ghost"
+                    )
+                  ]}>
+                    {entry.metadata["actor_role"]}
+                  </span>
                 <% end %>
-              </.table_default_cell>
-              <.table_default_cell class="text-xs text-base-content/60">
-                <%= if entry.target && entry.target_uuid != entry.resource_uuid do %>
-                  <div class="mb-0.5">
-                    <span class="text-base-content/50">&rarr;</span>
-                    <span>{entry.target.email}</span>
-                  </div>
-                <% end %>
-                <% summary = summarize_details(entry.metadata) %>
-                <%= if summary do %>
-                  <span>{summary}</span>
-                <% else %>
-                  <span class="text-base-content/30">—</span>
-                <% end %>
-              </.table_default_cell>
-              <.table_default_cell>
-                <%= if entry.resource_type do %>
-                  <span class="badge badge-ghost badge-xs">{entry.resource_type}</span>
-                  <%= case Map.get(@resource_users, entry.resource_uuid) do %>
-                    <% %{email: email} -> %>
-                      <span class="text-xs ml-1">{email}</span>
-                    <% _ -> %>
-                      <%= if entry.resource_uuid do %>
-                        <span class="text-xs text-base-content/40 ml-1">
-                          {String.slice(to_string(entry.resource_uuid), 0..7)}
-                        </span>
-                      <% end %>
-                  <% end %>
-                <% else %>
-                  <span class="text-base-content/30">—</span>
-                <% end %>
-              </.table_default_cell>
-              <.table_default_cell class="text-xs text-base-content/60">
-                <div>{Calendar.strftime(entry.inserted_at, "%b %d, %Y")}</div>
-                <div class="text-base-content/40">
-                  {Calendar.strftime(entry.inserted_at, "%H:%M:%S")}
+              <% else %>
+                <span class="text-base-content/50">System</span>
+              <% end %>
+            </.table_default_cell>
+            <.table_default_cell class="text-xs text-base-content/60">
+              <%= if entry.target && entry.target_uuid != entry.resource_uuid do %>
+                <div class="mb-0.5">
+                  <span class="text-base-content/50">&rarr;</span>
+                  <span>{entry.target.email}</span>
                 </div>
-              </.table_default_cell>
-              <.table_default_cell>
-                <.link
-                  navigate={Routes.path("/admin/activity/#{entry.uuid}")}
-                  class="btn btn-ghost btn-xs btn-square"
-                  title="View details"
-                >
-                  <.icon name="hero-arrow-top-right-on-square" class="w-4 h-4" />
-                </.link>
-              </.table_default_cell>
-            </.table_default_row>
-          <% end %>
-        </.table_default_body>
-      </.table_default>
-    <% end %>
+              <% end %>
+              <% summary = summarize_details(entry.metadata) %>
+              <%= if summary do %>
+                <span>{summary}</span>
+              <% else %>
+                <span class="text-base-content/30">—</span>
+              <% end %>
+            </.table_default_cell>
+            <.table_default_cell>
+              <%= if entry.resource_type do %>
+                <span class="badge badge-ghost badge-xs">{entry.resource_type}</span>
+                <%= case Map.get(@resource_users, entry.resource_uuid) do %>
+                  <% %{email: email} -> %>
+                    <span class="text-xs ml-1">{email}</span>
+                  <% _ -> %>
+                    <%= if entry.resource_uuid do %>
+                      <span class="text-xs text-base-content/40 ml-1">
+                        {String.slice(to_string(entry.resource_uuid), 0..7)}
+                      </span>
+                    <% end %>
+                <% end %>
+              <% else %>
+                <span class="text-base-content/30">—</span>
+              <% end %>
+            </.table_default_cell>
+            <.table_default_cell class="text-xs text-base-content/60">
+              <div>{Calendar.strftime(entry.inserted_at, "%b %d, %Y")}</div>
+              <div class="text-base-content/40">
+                {Calendar.strftime(entry.inserted_at, "%H:%M:%S")}
+              </div>
+            </.table_default_cell>
+            <.table_default_cell>
+              <.link
+                navigate={Routes.path("/admin/activity/#{entry.uuid}")}
+                class="btn btn-ghost btn-xs btn-square"
+                title="View details"
+              >
+                <.icon name="hero-arrow-top-right-on-square" class="w-4 h-4" />
+              </.link>
+            </.table_default_cell>
+          </.table_default_row>
+        <% end %>
+      </.table_default_body>
+    </.table_default>
 
     <%!-- Pagination --%>
     <%= if @total_pages > 1 do %>

--- a/lib/phoenix_kit_web/live/components/media_selector_modal.ex
+++ b/lib/phoenix_kit_web/live/components/media_selector_modal.ex
@@ -491,14 +491,19 @@ defmodule PhoenixKitWeb.Live.Components.MediaSelectorModal do
   # another object's folder but are also shared with this one.
   defp scope_files_by_folder(query, nil), do: query
 
+  # Scopes to the folder AND every nested folder beneath it, so a picker
+  # scoped to (e.g.) an order's folder also surfaces images uploaded into
+  # its sub-order subfolders.
   defp scope_files_by_folder(query, folder_uuid) do
+    folder_uuids = Storage.folder_subtree_uuids(folder_uuid)
+
     linked_subq =
       from(fl in FolderLink,
-        where: fl.folder_uuid == ^folder_uuid,
+        where: fl.folder_uuid in ^folder_uuids,
         select: fl.file_uuid
       )
 
-    where(query, [f], f.folder_uuid == ^folder_uuid or f.uuid in subquery(linked_subq))
+    where(query, [f], f.folder_uuid in ^folder_uuids or f.uuid in subquery(linked_subq))
   end
 
   defp scope_files_by_type(query, :image), do: where(query, [f], f.file_type == "image")

--- a/lib/phoenix_kit_web/live/components/media_selector_modal.html.heex
+++ b/lib/phoenix_kit_web/live/components/media_selector_modal.html.heex
@@ -38,7 +38,9 @@
                     {ngettext(
                       "%{count} selected",
                       "%{count} selected",
-                      MapSet.size(@selected_uuids), count: MapSet.size(@selected_uuids))}
+                      MapSet.size(@selected_uuids),
+                      count: MapSet.size(@selected_uuids)
+                    )}
                   </span>
                 <% end %>
               </p>

--- a/lib/phoenix_kit_web/live/users/live_sessions.html.heex
+++ b/lib/phoenix_kit_web/live/users/live_sessions.html.heex
@@ -97,20 +97,44 @@
       </PhoenixKitWeb.Components.Core.StatCard.stat_card>
     </div>
 
-    <%!-- Filters and Search --%>
-    <div class="card bg-base-100 shadow-xl mb-6">
-      <div class="card-body p-4">
-        <div class="flex flex-col md:flex-row gap-4 items-center justify-between">
+    <%!-- Sessions Table / Cards --%>
+    <.table_default
+      id="live-sessions-table"
+      variant="zebra"
+      toggleable={true}
+      items={@sessions}
+      card_fields={
+        fn session ->
+          [
+            %{label: "IP Address", value: session.ip_address || "Unknown"},
+            %{label: "Current Page", value: session.current_page || "—"},
+            %{
+              label: "Connected",
+              value: Calendar.strftime(session.connected_at, "%H:%M:%S %d/%m/%Y")
+            },
+            %{label: "Status", value: "● Active"}
+          ]
+        end
+      }
+    >
+      <:toolbar_title>
+        <div class="flex flex-wrap items-center gap-2">
           <%!-- Search --%>
-          <div class="flex-1 max-w-md">
-            <.search_toolbar
-              value={@search_query}
-              placeholder="Search by IP, User-Agent, email..."
-            />
-          </div>
-
+          <form phx-change="search" class="contents">
+            <label class="input input-sm w-40 sm:w-52 lg:w-64 min-w-0">
+              <.icon name="hero-magnifying-glass" class="h-4 w-4 opacity-50" />
+              <input
+                type="search"
+                name="search"
+                value={@search_query}
+                placeholder="Search by IP, User-Agent, email..."
+                class="grow"
+                phx-debounce="300"
+              />
+            </label>
+          </form>
           <%!-- Filter Tabs --%>
-          <div class="tabs tabs-boxed">
+          <div class="tabs tabs-boxed tabs-sm">
             <button
               phx-click="filter_by"
               phx-value-type="all"
@@ -134,29 +158,7 @@
             </button>
           </div>
         </div>
-      </div>
-    </div>
-
-    <%!-- Sessions Table / Cards --%>
-    <.table_default
-      id="live-sessions-table"
-      variant="zebra"
-      toggleable={true}
-      items={@sessions}
-      card_fields={
-        fn session ->
-          [
-            %{label: "IP Address", value: session.ip_address || "Unknown"},
-            %{label: "Current Page", value: session.current_page || "—"},
-            %{
-              label: "Connected",
-              value: Calendar.strftime(session.connected_at, "%H:%M:%S %d/%m/%Y")
-            },
-            %{label: "Status", value: "● Active"}
-          ]
-        end
-      }
-    >
+      </:toolbar_title>
       <:card_header :let={session}>
         <div class="flex items-start justify-between gap-2">
           <%= if session.type == :authenticated do %>

--- a/lib/phoenix_kit_web/live/users/sessions.html.heex
+++ b/lib/phoenix_kit_web/live/users/sessions.html.heex
@@ -111,62 +111,6 @@
       </div>
     <% end %>
 
-    <%!-- Controls --%>
-    <div class="bg-base-200 rounded-lg p-6 mb-6">
-      <div class="flex flex-col lg:flex-row gap-4 items-end">
-        <%!-- Search --%>
-        <div class="flex-1">
-          <label class="label">
-            <span class="label-text">Search by email or token</span>
-          </label>
-          <input
-            type="text"
-            value={@search_query}
-            phx-change="search"
-            phx-debounce="300"
-            name="search"
-            placeholder="Enter email address or token prefix..."
-            class="input input-bordered w-full"
-          />
-        </div>
-
-        <%!-- Filter by User Status --%>
-        <div>
-          <label class="label">
-            <span class="label-text">Filter by User Status</span>
-          </label>
-          <label class="select w-full max-w-xs">
-            <select
-              phx-change="filter_by_user_status"
-              name="status"
-            >
-              <option value="all" selected={@filter_user_status == "all"}>All Users</option>
-              <option value="active" selected={@filter_user_status == "active"}>
-                Active Users
-              </option>
-              <option value="inactive" selected={@filter_user_status == "inactive"}>
-                Inactive Users
-              </option>
-              <option value="confirmed" selected={@filter_user_status == "confirmed"}>
-                Confirmed Email
-              </option>
-              <option value="pending" selected={@filter_user_status == "pending"}>
-                Pending Email
-              </option>
-            </select>
-          </label>
-        </div>
-
-        <%!-- Refresh Button --%>
-        <button
-          phx-click="refresh_sessions"
-          class="btn btn-primary"
-        >
-          <.icon name="hero-arrow-path" class="w-4 h-4 mr-2" /> Refresh
-        </button>
-      </div>
-    </div>
-
     <%!-- Sessions Table / Cards --%>
     <.table_default
       id="sessions-table"
@@ -193,6 +137,47 @@
         end
       }
     >
+      <:toolbar_title>
+        <form phx-change="search" class="contents">
+          <label class="input input-sm w-40 sm:w-52 lg:w-64 min-w-0">
+            <.icon name="hero-magnifying-glass" class="h-4 w-4 opacity-50" />
+            <input
+              type="search"
+              name="search"
+              value={@search_query}
+              placeholder="Search by email or token..."
+              class="grow"
+              phx-debounce="300"
+            />
+          </label>
+        </form>
+      </:toolbar_title>
+      <:toolbar_actions>
+        <%!-- Filter by User Status --%>
+        <span class="text-sm text-base-content/70 whitespace-nowrap">
+          {gettext("Status:")}
+        </span>
+        <form phx-change="filter_by_user_status" class="contents">
+          <select class="select select-sm w-40 min-w-0" name="status">
+            <option value="all" selected={@filter_user_status == "all"}>All Users</option>
+            <option value="active" selected={@filter_user_status == "active"}>
+              Active Users
+            </option>
+            <option value="inactive" selected={@filter_user_status == "inactive"}>
+              Inactive Users
+            </option>
+            <option value="confirmed" selected={@filter_user_status == "confirmed"}>
+              Confirmed Email
+            </option>
+            <option value="pending" selected={@filter_user_status == "pending"}>
+              Pending Email
+            </option>
+          </select>
+        </form>
+        <button phx-click="refresh_sessions" class="btn btn-sm btn-primary">
+          <.icon name="hero-arrow-path" class="w-4 h-4" /> {gettext("Refresh")}
+        </button>
+      </:toolbar_actions>
       <:card_header :let={session}>
         <div class="flex items-start justify-between gap-2">
           <div class="flex flex-col min-w-0">

--- a/lib/phoenix_kit_web/live/users/users.html.heex
+++ b/lib/phoenix_kit_web/live/users/users.html.heex
@@ -74,46 +74,60 @@
       </div>
     <% end %>
 
-    <%!-- Controls --%>
-    <div class="bg-base-200 rounded-lg p-6 mb-6">
-      <div class="flex flex-col lg:flex-row gap-4">
-        <%!-- Search --%>
-        <div class="flex-1">
-          <label class="label">
-            <span class="label-text">Search by email, username, or name</span>
-          </label>
-          <.search_toolbar
-            value={@search_query}
-            placeholder="Enter email, username, or name to search..."
-          />
-        </div>
-
-        <%!-- Role Filter --%>
-        <div class="w-full lg:w-48">
-          <label class="label">
-            <span class="label-text">Filter by role</span>
-          </label>
-          <form phx-change="filter_by_role">
-            <label class="select w-full">
-              <select name="role" value={@filter_role}>
-                <option value="all">All Users</option>
-                <option value="Owner">Owners Only</option>
-                <option value="Admin">Admins Only</option>
-                <option value="User">Regular Users</option>
-              </select>
+    <%!-- Users Table --%>
+    <div class="bg-base-100">
+      <.table_default
+        id="users-table"
+        variant="zebra"
+        class="w-full"
+        toggleable={true}
+        items={@users}
+        card_title={fn user -> user.email end}
+        card_fields={
+          fn user ->
+            build_card_fields(
+              user,
+              @selected_columns,
+              @phoenix_kit_current_user,
+              @date_time_settings
+            )
+          end
+        }
+      >
+        <:toolbar_title>
+          <form phx-change="search" class="contents">
+            <label class="input input-sm w-full md:w-80 lg:w-96 min-w-0">
+              <.icon name="hero-magnifying-glass" class="h-4 w-4 opacity-50" />
+              <input
+                type="search"
+                name="search"
+                value={@search_query}
+                placeholder="Search by email, username, or name..."
+                class="grow"
+                phx-debounce="300"
+              />
             </label>
           </form>
-        </div>
-
-        <%!-- Account Type Filter --%>
-        <%= if @org_accounts_enabled do %>
-          <div class="w-full lg:w-48">
-            <label class="label">
-              <span class="label-text">{gettext("Account type")}</span>
-            </label>
-            <form phx-change="filter_by_account_type">
+        </:toolbar_title>
+        <:toolbar_actions>
+          <%!-- Role Filter --%>
+          <span class="text-sm text-base-content/70 whitespace-nowrap">Role:</span>
+          <form phx-change="filter_by_role" class="contents">
+            <select name="role" class="select select-sm w-36 min-w-0" value={@filter_role}>
+              <option value="all">All Users</option>
+              <option value="Owner">Owners Only</option>
+              <option value="Admin">Admins Only</option>
+              <option value="User">Regular Users</option>
+            </select>
+          </form>
+          <%!-- Account Type Filter --%>
+          <%= if @org_accounts_enabled do %>
+            <span class="text-sm text-base-content/70 whitespace-nowrap">
+              {gettext("Account type:")}
+            </span>
+            <form phx-change="filter_by_account_type" class="contents">
               <select
-                class="select select-bordered w-full"
+                class="select select-sm w-40 min-w-0"
                 name="account_type"
                 value={@filter_account_type}
               >
@@ -128,86 +142,82 @@
                 </option>
               </select>
             </form>
-          </div>
-        <% end %>
-
-        <%!-- Quick Actions --%>
-        <div class="w-full lg:w-auto">
-          <label class="label">
-            <span class="label-text">Quick Actions</span>
-          </label>
-          <div class="flex gap-2">
-            <button
-              class="btn btn-info"
-              phx-click="show_column_modal"
-              title="Customize columns"
-            >
-              <.icon name="hero-view-columns" class="h-5 w-5" />
-            </button>
-            <.link
-              navigate={PhoenixKit.Utils.Routes.path("/admin/users/new")}
-              class="btn btn-primary"
-            >
-              <PhoenixKitWeb.Components.Core.Icons.icon_user_add class="h-5 w-5" /> Add New User
-            </.link>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <%!-- Users Table --%>
-    <div class="bg-base-100">
-      <%= if length(@users) > 0 do %>
-        <.table_default
-          id="users-table"
-          variant="zebra"
-          class="w-full"
-          toggleable={true}
-          items={@users}
-          card_title={fn user -> user.email end}
-          card_fields={
-            fn user ->
-              build_card_fields(
-                user,
-                @selected_columns,
-                @phoenix_kit_current_user,
-                @date_time_settings
-              )
-            end
-          }
-        >
-          <:card_header :let={user}>
-            <div class="flex items-center gap-3">
-              <.user_avatar user={user} size="sm" />
-              <div class="flex flex-col gap-0.5 min-w-0">
-                <div class="flex flex-wrap items-center gap-2">
-                  <span class="font-medium text-sm truncate">{user.email}</span>
-                  <%= if user.uuid == @phoenix_kit_current_user.uuid do %>
-                    <span class="badge badge-info badge-xs h-auto">you</span>
-                  <% end %>
-                  <%= if User.full_name(user) && User.full_name(user) != "" do %>
-                    <span class="text-sm text-base-content/60">{User.full_name(user)}</span>
-                  <% end %>
-                </div>
-                <%= if user.username do %>
-                  <div class="text-xs text-base-content/50">@{user.username}</div>
+          <% end %>
+          <button
+            class="btn btn-sm btn-info"
+            phx-click="show_column_modal"
+            title="Customize columns"
+          >
+            <.icon name="hero-view-columns" class="h-4 w-4" />
+          </button>
+          <.link
+            navigate={PhoenixKit.Utils.Routes.path("/admin/users/new")}
+            class="btn btn-sm btn-primary"
+          >
+            <PhoenixKitWeb.Components.Core.Icons.icon_user_add class="h-4 w-4" /> Add New User
+          </.link>
+        </:toolbar_actions>
+        <:card_header :let={user}>
+          <div class="flex items-center gap-3">
+            <.user_avatar user={user} size="sm" />
+            <div class="flex flex-col gap-0.5 min-w-0">
+              <div class="flex flex-wrap items-center gap-2">
+                <span class="font-medium text-sm truncate">{user.email}</span>
+                <%= if user.uuid == @phoenix_kit_current_user.uuid do %>
+                  <span class="badge badge-info badge-xs h-auto">you</span>
+                <% end %>
+                <%= if User.full_name(user) && User.full_name(user) != "" do %>
+                  <span class="text-sm text-base-content/60">{User.full_name(user)}</span>
                 <% end %>
               </div>
-            </div>
-          </:card_header>
-          <.table_default_header>
-            <.table_default_row>
-              <%= for column_id <- @selected_columns do %>
-                <%= if should_render_column?(column_id) do %>
-                  <.table_default_header_cell>
-                    {render_column_header(column_id)}
-                  </.table_default_header_cell>
-                <% end %>
+              <%= if user.username do %>
+                <div class="text-xs text-base-content/50">@{user.username}</div>
               <% end %>
-            </.table_default_row>
-          </.table_default_header>
+            </div>
+          </div>
+        </:card_header>
+        <.table_default_header>
+          <.table_default_row>
+            <%= for column_id <- @selected_columns do %>
+              <%= if should_render_column?(column_id) do %>
+                <.table_default_header_cell>
+                  {render_column_header(column_id)}
+                </.table_default_header_cell>
+              <% end %>
+            <% end %>
+          </.table_default_row>
+        </.table_default_header>
 
-          <.table_default_body>
+        <.table_default_body>
+          <%= if @users == [] do %>
+            <.table_default_row>
+              <.table_default_cell colspan={length(@selected_columns)}>
+                <div class="text-center py-12">
+                  <PhoenixKitWeb.Components.Core.Icons.icon_users_multiple class="h-16 w-16 mx-auto text-base-content/40 mb-4" />
+                  <h3 class="text-lg font-medium text-base-content mb-2">
+                    No users found
+                  </h3>
+                  <p class="text-base-content/70 mb-4">
+                    <%= if @search_query != "" or @filter_role != "all" do %>
+                      Try adjusting your search or filter criteria.
+                    <% else %>
+                      No users are registered yet.
+                    <% end %>
+                  </p>
+                  <%= if @search_query != "" or @filter_role != "all" do %>
+                    <button
+                      class="btn btn-outline btn-sm"
+                      phx-click="search"
+                      phx-value-search=""
+                      onclick="document.querySelector('input[name=&quot;search&quot;]').value = ''"
+                    >
+                      Clear Filters
+                    </button>
+                  <% end %>
+                </div>
+              </.table_default_cell>
+            </.table_default_row>
+          <% else %>
             <%= for user <- @users do %>
               <.table_default_row>
                 <%= for column_id <- @selected_columns do %>
@@ -459,111 +469,86 @@
                 <% end %>
               </.table_default_row>
             <% end %>
-          </.table_default_body>
-          <:card_actions :let={user}>
-            <.table_row_menu id={"user-card-menu-#{user.uuid}"} label={gettext("User actions")}>
-              <.table_row_menu_link
-                navigate={PhoenixKit.Utils.Routes.path("/admin/users/view/#{user.uuid}")}
-                icon="hero-eye"
-                label={gettext("View")}
+          <% end %>
+        </.table_default_body>
+        <:card_actions :let={user}>
+          <.table_row_menu id={"user-card-menu-#{user.uuid}"} label={gettext("User actions")}>
+            <.table_row_menu_link
+              navigate={PhoenixKit.Utils.Routes.path("/admin/users/view/#{user.uuid}")}
+              icon="hero-eye"
+              label={gettext("View")}
+            />
+            <.table_row_menu_link
+              navigate={PhoenixKit.Utils.Routes.path("/admin/users/edit/#{user.uuid}")}
+              icon="hero-pencil"
+              label={gettext("Edit")}
+              variant="secondary"
+            />
+            <%= if user.uuid != @phoenix_kit_current_user.uuid do %>
+              <.table_row_menu_button
+                phx-click="show_role_management"
+                phx-value-user_uuid={user.uuid}
+                icon="hero-user-group"
+                label={gettext("Roles")}
+                variant="primary"
               />
+            <% end %>
+            <%= if user.uuid == @phoenix_kit_current_user.uuid do %>
               <.table_row_menu_link
-                navigate={PhoenixKit.Utils.Routes.path("/admin/users/edit/#{user.uuid}")}
-                icon="hero-pencil"
-                label={gettext("Edit")}
-                variant="secondary"
+                navigate={PhoenixKit.Utils.Routes.path("/dashboard/settings")}
+                icon="hero-cog-6-tooth"
+                label={gettext("Settings")}
+                variant="info"
               />
-              <%= if user.uuid != @phoenix_kit_current_user.uuid do %>
-                <.table_row_menu_button
-                  phx-click="show_role_management"
-                  phx-value-user_uuid={user.uuid}
-                  icon="hero-user-group"
-                  label={gettext("Roles")}
-                  variant="primary"
-                />
-              <% end %>
-              <%= if user.uuid == @phoenix_kit_current_user.uuid do %>
-                <.table_row_menu_link
-                  navigate={PhoenixKit.Utils.Routes.path("/dashboard/settings")}
-                  icon="hero-cog-6-tooth"
-                  label={gettext("Settings")}
-                  variant="info"
-                />
-              <% end %>
-              <%= if user.uuid != @phoenix_kit_current_user.uuid && get_primary_role_name_unsafe(user) != "Owner" do %>
+            <% end %>
+            <%= if user.uuid != @phoenix_kit_current_user.uuid && get_primary_role_name_unsafe(user) != "Owner" do %>
+              <.table_row_menu_divider />
+              <.table_row_menu_button
+                phx-click="request_confirmation_toggle"
+                phx-value-user_uuid={user.uuid}
+                phx-value-is_confirmed={to_string(!!user.confirmed_at)}
+                icon={if user.confirmed_at, do: "hero-envelope-open", else: "hero-envelope"}
+                label={if user.confirmed_at, do: gettext("Unconfirm"), else: gettext("Confirm")}
+                variant={if user.confirmed_at, do: "success", else: "warning"}
+              />
+              <.table_row_menu_button
+                phx-click="request_status_toggle"
+                phx-value-user_uuid={user.uuid}
+                phx-value-is_active={to_string(user.is_active)}
+                icon={if user.is_active, do: "hero-check-circle", else: "hero-x-circle"}
+                label={if user.is_active, do: gettext("Deactivate"), else: gettext("Activate")}
+                variant={if user.is_active, do: "success", else: "warning"}
+              />
+              <%= if Auth.can_delete_user?(user, @phoenix_kit_current_user) do %>
                 <.table_row_menu_divider />
                 <.table_row_menu_button
-                  phx-click="request_confirmation_toggle"
+                  phx-click="request_delete_user"
                   phx-value-user_uuid={user.uuid}
-                  phx-value-is_confirmed={to_string(!!user.confirmed_at)}
-                  icon={if user.confirmed_at, do: "hero-envelope-open", else: "hero-envelope"}
-                  label={if user.confirmed_at, do: gettext("Unconfirm"), else: gettext("Confirm")}
-                  variant={if user.confirmed_at, do: "success", else: "warning"}
+                  data-confirm="Are you sure you want to delete this user? This action cannot be undone."
+                  icon="hero-trash"
+                  label={gettext("Delete")}
+                  variant="error"
                 />
-                <.table_row_menu_button
-                  phx-click="request_status_toggle"
-                  phx-value-user_uuid={user.uuid}
-                  phx-value-is_active={to_string(user.is_active)}
-                  icon={if user.is_active, do: "hero-check-circle", else: "hero-x-circle"}
-                  label={if user.is_active, do: gettext("Deactivate"), else: gettext("Activate")}
-                  variant={if user.is_active, do: "success", else: "warning"}
-                />
-                <%= if Auth.can_delete_user?(user, @phoenix_kit_current_user) do %>
-                  <.table_row_menu_divider />
-                  <.table_row_menu_button
-                    phx-click="request_delete_user"
-                    phx-value-user_uuid={user.uuid}
-                    data-confirm="Are you sure you want to delete this user? This action cannot be undone."
-                    icon="hero-trash"
-                    label={gettext("Delete")}
-                    variant="error"
-                  />
-                <% end %>
               <% end %>
-            </.table_row_menu>
-          </:card_actions>
-        </.table_default>
-
-        <%!-- Pagination --%>
-        <%= if @total_pages > 1 do %>
-          <div class="flex justify-center p-4 border-t border-base-300">
-            <div class="join">
-              <%= for page <- 1..@total_pages do %>
-                <button
-                  class={"join-item btn btn-sm #{if page == @page, do: "btn-active", else: ""}"}
-                  phx-click="change_page"
-                  phx-value-page={page}
-                >
-                  {page}
-                </button>
-              <% end %>
-            </div>
-          </div>
-        <% end %>
-      <% else %>
-        <%!-- Empty state --%>
-        <div class="text-center py-12">
-          <PhoenixKitWeb.Components.Core.Icons.icon_users_multiple class="h-16 w-16 mx-auto text-base-content/40 mb-4" />
-          <h3 class="text-lg font-medium text-base-content mb-2">
-            No users found
-          </h3>
-          <p class="text-base-content/70 mb-4">
-            <%= if @search_query != "" or @filter_role != "all" do %>
-              Try adjusting your search or filter criteria.
-            <% else %>
-              No users are registered yet.
             <% end %>
-          </p>
-          <%= if @search_query != "" or @filter_role != "all" do %>
-            <button
-              class="btn btn-outline btn-sm"
-              phx-click="search"
-              phx-value-search=""
-              onclick="document.querySelector('input[name=&quot;search&quot;]').value = ''"
-            >
-              Clear Filters
-            </button>
-          <% end %>
+          </.table_row_menu>
+        </:card_actions>
+      </.table_default>
+
+      <%!-- Pagination --%>
+      <%= if @users != [] && @total_pages > 1 do %>
+        <div class="flex justify-center p-4 border-t border-base-300">
+          <div class="join">
+            <%= for page <- 1..@total_pages do %>
+              <button
+                class={"join-item btn btn-sm #{if page == @page, do: "btn-active", else: ""}"}
+                phx-click="change_page"
+                phx-value-page={page}
+              >
+                {page}
+              </button>
+            <% end %>
+          </div>
         </div>
       <% end %>
     </div>

--- a/test/integration/storage/scope_test.exs
+++ b/test/integration/storage/scope_test.exs
@@ -562,6 +562,25 @@ defmodule PhoenixKit.Integration.Storage.ScopeTest do
   # trash_folder / restore_folder / delete_folder_completely (V119)
   # ---------------------------------------------------------------------------
 
+  describe "folder_subtree_uuids/1" do
+    test "returns the root and every nested descendant, excluding siblings" do
+      %{scope: scope, child_a: a, child_b: b, grandchild: g, sibling: sibling} = build_tree()
+
+      uuids = MapSet.new(Storage.folder_subtree_uuids(scope.uuid))
+
+      assert MapSet.member?(uuids, scope.uuid)
+      assert MapSet.member?(uuids, a.uuid)
+      assert MapSet.member?(uuids, b.uuid)
+      assert MapSet.member?(uuids, g.uuid)
+      refute MapSet.member?(uuids, sibling.uuid)
+    end
+
+    test "a leaf folder returns just itself" do
+      %{grandchild: g} = build_tree()
+      assert Storage.folder_subtree_uuids(g.uuid) == [g.uuid]
+    end
+  end
+
   describe "trash_folder/2" do
     test "recursively trashes the folder + descendants + files in subtree" do
       %{scope: scope, child_a: child_a, grandchild: grandchild} = build_tree()


### PR DESCRIPTION
## Summary

- Fix media picker to include images in nested subfolders
- Merge upstream/dev (release 1.7.112, new core components and utilities)
- Fix users search regression: search broke when `on_submit` was dropped from `<.search_toolbar>`, leaving a form-less `<input>` whose `phx-change` never delivers the event — search inputs are now wrapped in a `<form phx-change="search">`
- Move the search/filter/button panels above the Users, Live Sessions, and Sessions tables into the `<.table_default>` toolbar row
- Move the Activity page filters into the table toolbar row; Clear filters becomes an outlined button shown only when a filter is active

## Commits

- `438e488f` Fix media picker to include images in nested subfolders
- `41245259` Merge remote-tracking branch 'upstream/dev' into dev
- `30c9398f` Fix users search regression and move filters into table toolbar
- `432ae380` Move Activity filters into table toolbar row